### PR TITLE
Add changeset + release workflow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,35 @@
+# Changesets
+
+This directory holds [changeset](https://github.com/changesets/changesets) files
+— per-change descriptions that drive the automated version bump workflow.
+
+## Workflow
+
+1. **You open a PR.** If the change is user-facing (anything that should appear
+   in the changelog or trigger a version bump), run:
+
+   ```sh
+   npm run changeset
+   ```
+
+   Pick `patch` / `minor` / `major`, write a short summary, and commit the
+   resulting `.changeset/*.md` file with your PR.
+
+2. **PR merges to `main`.** The `Release` workflow (`.github/workflows/release.yml`)
+   notices the pending changesets and opens a "Version Packages" PR that:
+   - Runs `changeset version` to bump `package.json`.
+   - Runs `scripts/sync-manifest-versions.mjs` to sync the new version into
+     `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
+     `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and
+     `gemini-extension.json`.
+   - Updates `CHANGELOG.md`.
+
+3. **You merge the Version Packages PR.** The workflow then runs
+   `changeset tag` to push a git tag and create a GitHub release for the
+   new version. Nothing is published to npm.
+
+## Skipping the changeset
+
+Pure infra / refactor / docs changes that should not appear in the changelog
+don't need a changeset. Open the PR without one — the release workflow will
+ignore it.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: changesets/action@v1
+        with:
+          version: npm run version-packages
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# subtext-review

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "subtext-review",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "changeset": "npx --yes @changesets/cli@^2.27.0",
+    "version-packages": "npx --yes @changesets/cli@^2.27.0 version && node scripts/sync-manifest-versions.mjs",
+    "release": "npx --yes @changesets/cli@^2.27.0 tag"
+  }
+}

--- a/scripts/sync-manifest-versions.mjs
+++ b/scripts/sync-manifest-versions.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Sync the per-harness manifest versions to package.json's version.
+//
+// Changesets only bumps `package.json`; the per-harness plugin.json files
+// (.claude-plugin/, .codex-plugin/, .cursor-plugin/), the Gemini extension
+// manifest (gemini-extension.json), and the marketplace listing carry their
+// own `version` fields that the harnesses' UIs display.
+// This script reads the post-`changeset version` package.json and writes
+// that version into every manifest, so a future Version PR opens with all
+// manifests already synced.
+//
+// Wired into `npm run version-packages`, which `release.yml` invokes via
+// `changesets/action`'s `version:` input.
+//
+// Pure Node.js (no deps). Idempotent.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { version } = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
+
+const PER_HARNESS_MANIFESTS = [
+  '.claude-plugin/plugin.json',
+  '.codex-plugin/plugin.json',
+  '.cursor-plugin/plugin.json',
+  'gemini-extension.json',
+];
+
+let touched = 0;
+
+for (const rel of PER_HARNESS_MANIFESTS) {
+  const path = join(REPO_ROOT, rel);
+  if (!existsSync(path)) continue;
+  const json = JSON.parse(readFileSync(path, 'utf8'));
+  if (json.version === version) continue;
+  json.version = version;
+  writeFileSync(path, JSON.stringify(json, null, 2) + '\n');
+  console.log(`sync: ${rel} → ${version}`);
+  touched++;
+}
+
+// marketplace.json: version lives under plugins[0].
+const marketplacePath = join(REPO_ROOT, '.claude-plugin/marketplace.json');
+if (existsSync(marketplacePath)) {
+  const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
+  if (marketplace.plugins[0].version !== version) {
+    marketplace.plugins[0].version = version;
+    writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + '\n');
+    console.log(`sync: .claude-plugin/marketplace.json (plugins[0]) → ${version}`);
+    touched++;
+  }
+}
+
+if (touched === 0) {
+  console.log(`sync: all manifests already at ${version}`);
+}


### PR DESCRIPTION
## Summary

- Ports the standalone changeset/release machinery from the original `subtext` repo so `subtext-review` can version and tag itself independently as its own marketplace plugin
- On push to `main`, `changesets/action@v1` either opens a "Version Packages" PR (bumps `package.json` + syncs all manifests via `scripts/sync-manifest-versions.mjs`) or creates a git tag + GitHub release — no npm publish
- No devDeps required; changesets CLI is invoked via `npx --yes @changesets/cli@^2.27.0`

### Verification

`node scripts/sync-manifest-versions.mjs` runs clean locally:
```
sync: all manifests already at 0.1.0
```

### Skill audit — confirmed clean

The `subtext-review` skill set is already focused for read-only session review:
- **No `hooks/` directory** — the SessionStart proof-bootstrap hook lives only in `subtext-verify`
- Skills are the focused 6: `privacy`, `review`, `session`, `setup-plugin`, `shared`, `using-subtext` — no `proof`, `live`, `tunnel`, `docs`, or `comments`
- `skills/using-subtext/SKILL.md` is framed as read-only "Using Subtext Review"; explicitly redirects proof/live work to the separate Subtext Verify plugin
- `skills/review/SKILL.md` is a clean read-only review loop with no proof emphasis

No skill changes needed.

## Test plan

- [ ] Confirm workflow YAML is valid (GitHub Actions will parse it on first push to main)
- [ ] Open a test PR with a `.changeset/*.md` file — verify the Release workflow opens a "Version Packages" PR on merge
- [ ] Merge the Version Packages PR — verify a git tag and GitHub release are created