### PR TITLE
Prefix all skills with `subtext-` (SUBTEXT-379)

### DIFF
--- a/.changeset/subtext-prefix-skills.md
+++ b/.changeset/subtext-prefix-skills.md
@@ -1,0 +1,7 @@
+---
+"subtext-review": minor
+---
+
+Prefix every skill folder with `subtext-` (e.g. `subtext-review`, `subtext-session`, `subtext-privacy`, `subtext-shared`, `subtext-using-subtext`, `subtext-setup-plugin`).
+
+The namespace now lives in the skill folder name itself, so skills stay collision-free across the harnesses that don't namespace plugins (Cursor, `.agents/skills`, `npx openskills`). Skill invocation names change accordingly — e.g. in Claude Code the review skill is now `subtext-review:subtext-review`. Cross-references in skill bodies and the README were updated to match.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Read-only review of Fullstory session recordings, plus privacy-rule management, 
 
 This plugin bundles:
 
-- **Skills** — `review` (structured session summaries), `session` (the `review-*` tool catalog), `privacy` (PII detection + element-block rules), plus `shared` and `using-subtext`.
+- **Skills** — `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block rules), plus `subtext-shared` and `subtext-using-subtext`.
 - **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1 mirror: `https://api.eu1.fullstory.com/mcp/subtext`). HTTP only — no local process required.
 
 ## Install

--- a/skills/subtext-privacy/SKILL.md
+++ b/skills/subtext-privacy/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: privacy
+name: subtext-privacy
 description: Privacy rule management — detect PII in sessions and manage element-block rules. Use when you need to propose, create, list, delete, or promote CSS-selector-based privacy rules for a Fullstory org.
 ---
 
 # Privacy
 
-> **PREREQUISITE:** Read `shared` for MCP conventions.
+> **PREREQUISITE:** Read `subtext-shared` for MCP conventions.
 
 Privacy tools manage element-block rules — CSS-selector-based rules that mask or exclude specific page elements from Fullstory session recordings.
 
@@ -95,5 +95,5 @@ privacy-delete rule_ids=["<id1>"]
 
 ## See Also
 
-- `shared` — MCP conventions
-- `session` — session replay tools (for obtaining a session URL to pass to `propose`)
+- `subtext-shared` — MCP conventions
+- `subtext-session` — session replay tools (for obtaining a session URL to pass to `propose`)

--- a/skills/subtext-review/SKILL.md
+++ b/skills/subtext-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: review
+name: subtext-review
 description: Review a completed Subtext session and produce a structured summary. Use when you have a session URL and want to understand what happened — verify a flow, walk through a dev / staging / preview session, or summarize a captured session. Optionally emits reproduction steps on request.
 ---
 
 # Review
 
-> **PREREQUISITE:** Read `shared` and `session` for tool conventions.
+> **PREREQUISITE:** Read `subtext-shared` and `subtext-session` for tool conventions.
 
 **Type:** Workflow — goal-oriented with decision logic.
 
@@ -25,7 +25,7 @@ Review a completed session and produce a structured summary of what happened. Op
 
 ### Step 1: Open the session
 
-Call `review-open` with whichever identifier you have — see `session` for the five accepted forms. Capture the `trace_id` from the response.
+Call `review-open` with whichever identifier you have — see `subtext-session` for the five accepted forms. Capture the `trace_id` from the response.
 
 ### Step 2: Read the session content
 

--- a/skills/subtext-session/SKILL.md
+++ b/skills/subtext-session/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: session
+name: subtext-session
 description: Session replay tools for analyzing Fullstory session recordings. Sparse API catalog — tools are self-describing.
 ---
 
 # Session Replay
 
-> **PREREQUISITE:** Read `shared` for MCP conventions.
+> **PREREQUISITE:** Read `subtext-shared` for MCP conventions.
 
 API catalog for the session replay tools (all prefixed `review-`). These tools let you open sessions, inspect UI state at specific timestamps, and compare state across time.
 
@@ -44,4 +44,4 @@ All five paths return the same trace_id-keyed handle; the entry point doesn't ch
 
 ## See Also
 
-- `shared` — MCP conventions
+- `subtext-shared` — MCP conventions

--- a/skills/subtext-setup-plugin/SKILL.md
+++ b/skills/subtext-setup-plugin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup-plugin
+name: subtext-setup-plugin
 description: Install the Subtext Review plugin and verify the MCP server is connected. Authenticates via OAuth or API key.
 ---
 
@@ -46,5 +46,5 @@ Re-run the connectivity check after authenticating.
 
 After setup, explain what was installed:
 
-- **Skills** — `review` (structured summary of a session), `session` (the `review-*` tool catalog), `privacy` (PII detection + element-block rules).
+- **Skills** — `subtext-review` (structured summary of a session), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block rules).
 - **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1: `https://api.eu1.fullstory.com/mcp/subtext`).

--- a/skills/subtext-shared/SKILL.md
+++ b/skills/subtext-shared/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: shared
+name: subtext-shared
 description: Foundation skill for the Subtext Review plugin. MCP tool conventions and security rules. Read this when any skill lists it in PREREQUISITE.
 ---
 
@@ -20,7 +20,7 @@ All tools are served from the **subtext** MCP server. A **subtext-eu1** variant 
 
 ## Discovering MCP Tool Parameters
 
-Each MCP tool is self-describing. If you're unsure about parameters, the tool's schema is available at call time. Don't memorize parameter lists — consult the atomic skill (`session` or `privacy`) for which tools exist, then let the schema guide parameter usage.
+Each MCP tool is self-describing. If you're unsure about parameters, the tool's schema is available at call time. Don't memorize parameter lists — consult the atomic skill (`subtext-session` or `subtext-privacy`) for which tools exist, then let the schema guide parameter usage.
 
 ## Security Rules
 

--- a/skills/subtext-using-subtext/SKILL.md
+++ b/skills/subtext-using-subtext/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: using-subtext
+name: subtext-using-subtext
 description: Overview of the Subtext Review plugin — when to reach for session review vs privacy tools. Read to orient before reviewing a Fullstory session or managing privacy rules.
 ---
 
@@ -11,9 +11,9 @@ This plugin gives you read-only access to Fullstory session recordings, plus pri
 
 | Signal | Skill |
 |--------|-------|
-| You have a session URL / want to know what happened | `review` |
-| You need the session-replay tool catalog (`review-*`) | `session` |
-| Detect PII or manage element-block privacy rules | `privacy` |
+| You have a session URL / want to know what happened | `subtext-review` |
+| You need the session-replay tool catalog (`review-*`) | `subtext-session` |
+| Detect PII or manage element-block privacy rules | `subtext-privacy` |
 
 ## Notes
 


### PR DESCRIPTION
Renames every skill folder to a `subtext-` prefix so the namespace lives in the folder name itself — keeping skills collision-free across harnesses that don't namespace plugins (Cursor, `.agents/skills`, `npx openskills`).

## What changed
- `skills/<x>` → `skills/subtext-<x>` for all six skills (privacy, review, session, setup-plugin, shared, using-subtext).
- Prefixed each SKILL.md frontmatter `name:` to match its folder.
- Updated all backtick cross-references in skill bodies and the README (tool names like `review-*` / `review-open` left untouched).
- Added a changeset (minor).

## Tradeoff (by design)
In Claude Code plugin installs this surfaces as the doubled form `subtext-review:subtext-review`. We're accepting that cosmetic cost in exchange for collision-safety everywhere else and a single, simple skill repo.

## Context
- Decision + findings: https://www.notion.so/Subtext-skill-naming-384f4b241a5e800c9b58ec2ac588b886
- Ticket: SUBTEXT-379

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill packaging rename only; no runtime, auth, or MCP behavior changes.
> 
> **Overview**
> Renames all six plugin skills so the **`subtext-` namespace lives in each skill folder and frontmatter `name`**, avoiding collisions on harnesses that don’t namespace by plugin (Cursor, `.agents/skills`, `npx openskills`).
> 
> **README**, **setup** copy, and **PREREQUISITE / See Also** links now point at `subtext-review`, `subtext-session`, `subtext-privacy`, `subtext-shared`, `subtext-using-subtext`, and `subtext-setup-plugin`. MCP tool names (`review-*`, `privacy-*`) are unchanged. A **minor changeset** documents the rename and notes that Claude Code may show doubled invocation ids like `subtext-review:subtext-review`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3d0a1a737b4c6504240150312938d89b8328be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->