### PR TITLE
Rename plugin from subtext-review to subtext

### DIFF
--- a/.changeset/subtext-prefix-skills.md
+++ b/.changeset/subtext-prefix-skills.md
@@ -1,7 +1,7 @@
 ---
-"subtext-review": minor
+"subtext": minor
 ---
 
 Prefix every skill folder with `subtext-` (e.g. `subtext-review`, `subtext-session`, `subtext-privacy`, `subtext-shared`, `subtext-using-subtext`, `subtext-setup-plugin`).
 
-The namespace now lives in the skill folder name itself, so skills stay collision-free across the harnesses that don't namespace plugins (Cursor, `.agents/skills`, `npx openskills`). Skill invocation names change accordingly — e.g. in Claude Code the review skill is now `subtext-review:subtext-review`. Cross-references in skill bodies and the README were updated to match.
+The namespace now lives in the skill folder name itself, so skills stay collision-free across the harnesses that don't namespace plugins (Cursor, `.agents/skills`, `npx openskills`). Skill invocation names change accordingly — e.g. in Claude Code the review skill is now `subtext:subtext-review`. Cross-references in skill bodies and the README were updated to match.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "subtext",
       "source": "./",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "description": "Review Fullstory session recordings and manage privacy rules",
       "category": "development",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "plugins": [
     {
-      "name": "subtext-review",
+      "name": "subtext",
       "source": "./",
       "version": "0.1.0",
       "description": "Review Fullstory session recordings and manage privacy rules",
@@ -19,7 +19,7 @@
         "review",
         "privacy"
       ],
-      "homepage": "https://github.com/fullstorydev/subtext-review"
+      "homepage": "https://github.com/fullstorydev/subtext"
     },
     {
       "name": "subtext-verify",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "subtext-review",
+  "name": "subtext",
   "version": "0.1.0",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subtext",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "license": "MIT",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "subtext-review",
+  "name": "subtext",
   "version": "0.1.0",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "subtext",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "author": {
     "name": "Subtext",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "subtext",
   "description": "Review Fullstory session recordings and manage privacy rules",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "license": "MIT",
   "author": {
     "name": "Subtext",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "subtext-review",
+  "name": "subtext",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "version": "0.1.0",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-# subtext-review
+# subtext

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Subtext Review
+# Subtext
 
 Read-only review of Fullstory session recordings, plus privacy-rule management, for coding agents.
 
@@ -11,22 +11,22 @@ This plugin bundles:
 
 **Claude Code**
 ```
-/plugin marketplace add fullstorydev/subtext-review
-/plugin install subtext-review@subtext-marketplace
+/plugin marketplace add fullstorydev/subtext
+/plugin install subtext@subtext-marketplace
 ```
 
 **Cursor** — install from the Marketplace panel (or a Team Marketplace that imports this repo).
 
-**Codex** — open `/plugins`, install **subtext-review** from the repo marketplace.
+**Codex** — open `/plugins`, install **subtext** from the repo marketplace.
 
 **Gemini CLI**
 ```
-gemini extensions install https://github.com/fullstorydev/subtext-review
+gemini extensions install https://github.com/fullstorydev/subtext
 ```
 
 **Manual / openskills**
 ```
-npx openskills install fullstorydev/subtext-review
+npx openskills install fullstorydev/subtext
 ```
 …then add the `subtext` MCP server (URL above) to your agent's MCP configuration.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
-  "name": "subtext-review",
+  "name": "subtext",
   "version": "0.1.0",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "mcpServers": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "subtext",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "Review Fullstory session recordings and manage privacy rules",
   "mcpServers": {
     "subtext": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "subtext-review",
+  "name": "subtext",
   "version": "0.1.0",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subtext",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "changeset": "npx --yes @changesets/cli@^2.27.0",

--- a/skills/subtext-setup-plugin/SKILL.md
+++ b/skills/subtext-setup-plugin/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: subtext-setup-plugin
-description: Install the Subtext Review plugin and verify the MCP server is connected. Authenticates via OAuth or API key.
+description: Install the Subtext plugin and verify the MCP server is connected. Authenticates via OAuth or API key.
 ---
 
 # Setup Plugin
 
-Install and verify the Subtext Review plugin/extension. Works for Claude Code, Cursor, Codex, and Gemini CLI.
+Install and verify the Subtext plugin/extension. Works for Claude Code, Cursor, Codex, and Gemini CLI.
 
 ## Pre-check
 
@@ -20,14 +20,14 @@ If MCP tools are not available, the plugin needs to be installed. The command de
 **Claude Code:**
 
 ```
-/plugin marketplace add fullstorydev/subtext-review
-/plugin install subtext-review@subtext-marketplace
+/plugin marketplace add fullstorydev/subtext
+/plugin install subtext@subtext-marketplace
 ```
 
 **Gemini CLI:**
 
 ```
-gemini extensions install https://github.com/fullstorydev/subtext-review
+gemini extensions install https://github.com/fullstorydev/subtext
 ```
 
 Note: Slash commands can't be executed by the agent — the user must run them directly.

--- a/skills/subtext-shared/SKILL.md
+++ b/skills/subtext-shared/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: subtext-shared
-description: Foundation skill for the Subtext Review plugin. MCP tool conventions and security rules. Read this when any skill lists it in PREREQUISITE.
+description: Foundation skill for the Subtext plugin. MCP tool conventions and security rules. Read this when any skill lists it in PREREQUISITE.
 ---
 
 # Shared
 
-Foundation for all Subtext Review skills. Read this when a skill lists it in PREREQUISITE.
+Foundation for all Subtext skills. Read this when a skill lists it in PREREQUISITE.
 
 ## MCP Servers
 

--- a/skills/subtext-using-subtext/SKILL.md
+++ b/skills/subtext-using-subtext/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: subtext-using-subtext
-description: Overview of the Subtext Review plugin — when to reach for session review vs privacy tools. Read to orient before reviewing a Fullstory session or managing privacy rules.
+description: Overview of the Subtext plugin — when to reach for session review vs privacy tools. Read to orient before reviewing a Fullstory session or managing privacy rules.
 ---
 
-# Using Subtext Review
+# Using Subtext
 
 This plugin gives you read-only access to Fullstory session recordings, plus privacy-rule management.
 


### PR DESCRIPTION
## Summary

Two related cleanups after the repo's cutover to **Session Review** (broader validation/verification moved to `subtext-verify`):

1. **Rename** `subtext-review` → `subtext` everywhere it referred to the plugin/package/repo (not the review *skill*).
2. **Version bump** `0.1.0` → `0.5.0` across all manifests.

## Rename → `subtext` / `Subtext` / `fullstorydev/subtext`

- Manifests: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (entry `name` + `homepage`), `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`, `package.json`
- Docs: `README.md` (title, install commands, repo slugs/URLs), `CHANGELOG.md` title
- Changeset: `.changeset/subtext-prefix-skills.md` package key + invocation example
- Skill prose: `subtext-setup-plugin`, `subtext-using-subtext`, `subtext-shared`

Deliberately left as `subtext-review` (the *skill*, not a miss): `skills/subtext-review/SKILL.md` `name:`, the skill-list references, and the skill half of `subtext:subtext-review`.

## Version: 0.1.0 → 0.5.0

The git history rewrite reset every manifest to `0.1.0`. The **last published version was `0.3.1`** (recovered from the locally-installed `subtext@subtext-marketplace` plugin: `~/.claude/plugins/installed_plugins.json` + cache dir `.../subtext/0.3.1/`). Publishing at `0.1.0` would break marketplace auto-update — clients on `0.3.1` would see a *lower* version and never update. Set to `0.5.0` to clear `0.3.1` and any unpublished `0.4.0`.

All six manifests now read `0.5.0`.

## Notes

- The GitHub repo rename `subtext-review` → `subtext` (if not already done) must happen on GitHub for the `fullstorydev/subtext` URLs to resolve.
- The pending `minor` changeset (`subtext-prefix-skills.md`) means the next automated release will compute `0.5.0` → `0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)