### PR TITLE
Document URL and network privacy rule MCP tools

### DIFF
--- a/.changeset/url-network-privacy-tools.md
+++ b/.changeset/url-network-privacy-tools.md
@@ -1,0 +1,9 @@
+---
+"subtext": minor
+---
+
+Document `privacy-url-list`, `privacy-url-create`, `privacy-network-list`, and `privacy-network-create` in the `subtext-privacy` skill — new MCP tools for managing URL privacy rules (scrub host/path/query) and network privacy rules (elide/allowlist request-response bodies), alongside the existing element-block rule tools.
+
+`privacy-url-create` and `privacy-network-create` also double as update: pass `guid` (URL rules) or `overwrite=true` (network rules) to replace an existing rule in place instead of creating a new one. Unlike element rules, URL and network rules have no preview/promote scope — created or updated rules apply to all sessions immediately.
+
+Cross-references in `subtext-shared`, `subtext-using-subtext`, `subtext-setup-plugin`, and the README were updated to match.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Read-only review of Fullstory session recordings, plus privacy-rule management, 
 
 This plugin bundles:
 
-- **Skills** — `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block rules), plus `subtext-shared` and `subtext-using-subtext`.
+- **Skills** — `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules), plus `subtext-shared` and `subtext-using-subtext`.
 - **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1 mirror: `https://api.eu1.fullstory.com/mcp/subtext`). HTTP only — no local process required.
 
 ## Install
@@ -32,5 +32,5 @@ npx openskills install fullstorydev/subtext
 
 ## Notes
 
-- All tools are read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete`, which modify org privacy rules.
+- All tools are read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete` / `privacy-url-create` / `privacy-network-create`, which modify org privacy rules.
 - Driving a live browser and capturing before/after proof of code changes live in the separate **Subtext Verify** plugin.

--- a/skills/subtext-privacy/SKILL.md
+++ b/skills/subtext-privacy/SKILL.md
@@ -1,25 +1,35 @@
 ---
 name: subtext-privacy
-description: Privacy rule management — detect PII in sessions and manage element-block rules. Use when you need to propose, create, list, delete, or promote CSS-selector-based privacy rules for a Fullstory org.
+description: Privacy rule management — detect PII in sessions and manage element-block, URL, and network privacy rules. Use when you need to propose, create, list, delete, or promote privacy rules for a Fullstory org.
 ---
 
 # Privacy
 
 > **PREREQUISITE:** Read `subtext-shared` for MCP conventions.
 
-Privacy tools manage element-block rules — CSS-selector-based rules that mask or exclude specific page elements from Fullstory session recordings.
+Privacy tools manage three kinds of rules that control what Fullstory session recordings capture:
+
+- **Element rules** — CSS-selector-based rules that mask or exclude specific page elements.
+- **URL rules** — scrub sensitive parts of captured URLs (host/path/query).
+- **Network rules** — control whether request/response bodies are captured, redacted, or partially allowlisted.
 
 ## MCP Tools
 
 | Tool | Description |
 |------|-------------|
-| `privacy-propose` | Scan a session for PII and return suggested selectors (dry-run — persists nothing). |
+| `privacy-propose` | Scan a session for PII and return suggested selectors (dry-run — persists nothing). Element rules only. |
 | `privacy-create` | Create element-block rules from selectors in preview scope. |
 | `privacy-list` | List existing element-block rules, with optional scope/type filters. |
 | `privacy-delete` | Delete preview-scoped rules by ID. |
 | `privacy-promote` | Promote preview-scoped rules to apply to all sessions. |
+| `privacy-url-list` | List URL privacy rules. |
+| `privacy-url-create` | Create a URL privacy rule that scrubs host/path/query, or update one in place by passing `guid`. Live immediately. |
+| `privacy-network-list` | List network (request/response body) privacy rules. |
+| `privacy-network-create` | Create a network privacy rule (elide or allowlist body fields), or update the existing rule for a `url_regex` by passing `overwrite=true`. Live immediately. |
 
-## Rule lifecycle
+Listing and creation are supported for all three rule kinds. There's no separate update tool for URL/network rules — `privacy-url-create`/`privacy-network-create` double as update when you pass `guid`/`overwrite`. Deletion is only supported for element rules today.
+
+## Rule lifecycle (element rules)
 
 Rules always start in **preview scope** (`PREVIEW_SESSIONS_ONLY`) and must be explicitly promoted to apply broadly:
 
@@ -39,6 +49,44 @@ promote → ALL_SESSIONS
 delete (preview only)
 ```
 
+## URL and network rules: no preview step
+
+Unlike element rules, **URL and network rules have no scope and no preview/promote lifecycle.** `privacy-url-create` and `privacy-network-create` take effect for **all sessions immediately** — there is nothing to promote, and (for now) nothing to delete via MCP. Double-check a rule before creating it; use `privacy-url-list` / `privacy-network-list` afterward to confirm what's live.
+
+### URL rules
+
+`privacy-url-create` takes a `name` plus either simplified fields or a raw `advanced` override:
+
+```
+privacy-url-create name="scrub-ssn-param" match_host="example\.com" exclude_query_params=["ssn"]
+```
+
+This redacts the `ssn` query parameter's value (not its key) on URLs whose host matches `example\.com`. Leave `match_host`/`match_path` both empty for an unconditional rule (applies to every URL). Use `exclude_path` / `exclude_query` for a raw regex against the path or full query string instead of a named param. Use `advanced` (structured `if`/`exclude` pattern sets over hash/host/path/query_param/query) only when the simplified fields can't express the rule.
+
+**Updating a URL rule:** pass the rule's `guid` (from `privacy-url-list`) to replace it in place instead of creating a new one:
+
+```
+privacy-url-create guid="<guid>" name="scrub-ssn-param" match_host="example\.com" exclude_query_params=["ssn", "token"]
+```
+
+Update is a **full replace**, not a merge — pass the complete desired state (name, condition, exclusions), not just the field you're changing. Built-in rules (part of the default rule set created at privacy settings setup) cannot be updated this way.
+
+### Network rules
+
+`privacy-network-create` takes a `url_regex` plus request/response body handling:
+
+```
+privacy-network-create url_regex="/api/checkout/.*" request_body="whitelist" request_allowlist_fields=["order_id", "status"]
+```
+
+Only `elide` (default, redact the whole body) and `whitelist` (keep only named fields) are supported for automated creation/update — `record` (capture the full body) increases data capture and must be set up manually. Rules are keyed by `url_regex`; without `overwrite`, creating a rule for a regex that already has one is a no-op.
+
+**Updating a network rule:** pass `overwrite=true` to replace the existing rule for that `url_regex` instead of skipping it:
+
+```
+privacy-network-create url_regex="/api/checkout/.*" request_body="whitelist" request_allowlist_fields=["order_id", "status", "total"] overwrite=true
+```
+
 ## Rules and constraints
 
 - `privacy-propose` is always a **dry-run**. It returns suggested selectors but persists nothing. Use it to preview before committing.
@@ -46,6 +94,9 @@ delete (preview only)
 - `privacy-delete` only accepts preview-scoped rules. Promoted rules cannot be deleted here.
 - `privacy-promote` also rejects unmask rules — only mask and exclude rules can be promoted.
 - System-managed rules (not user-created) are hidden by default. Pass `include_system=true` to `privacy-list` to see them. These rules cannot be deleted or promoted.
+- `privacy-url-create` and `privacy-network-create` rules go live for all sessions immediately — there's no preview scope to validate in first.
+- `privacy-network-create` rejects `record` for request/response body mode; only `elide` and `whitelist` are allowed.
+- Neither URL nor network rules currently support deletion via MCP — use the Fullstory settings UI if a rule needs to be removed.
 
 ## Typical flow
 
@@ -92,6 +143,10 @@ privacy-delete rule_ids=["<id1>"]
 - Creating rules and immediately promoting — always verify with a preview session first. The preview scope exists for exactly this purpose.
 - Trying to delete a promoted rule — `delete` only works on preview-scoped rules.
 - Using `unmask` as `block_type` in `create` — this is rejected. Unmask rules are system-managed.
+- Assuming `privacy-url-create` / `privacy-network-create` land in a preview scope like element rules — they don't. They apply to all sessions the moment they're created, so double-check the pattern/regex before calling.
+- Using `request_body="record"` (or `response_body="record"`) in `privacy-network-create` — this is rejected; only `elide` and `whitelist` are supported for automated creation.
+- Passing `guid` to `privacy-url-create` with only the field you want to change — update is a full replace, so omitted fields (name, condition, exclusions) are lost, not preserved. Fetch the current rule from `privacy-url-list` first and resend its full state.
+- Forgetting `overwrite=true` on `privacy-network-create` when you meant to change an existing rule — without it, a matching `url_regex` is silently skipped, not updated.
 
 ## See Also
 

--- a/skills/subtext-setup-plugin/SKILL.md
+++ b/skills/subtext-setup-plugin/SKILL.md
@@ -46,5 +46,5 @@ Re-run the connectivity check after authenticating.
 
 After setup, explain what was installed:
 
-- **Skills** — `subtext-review` (structured summary of a session), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block rules).
+- **Skills** — `subtext-review` (structured summary of a session), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules).
 - **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1: `https://api.eu1.fullstory.com/mcp/subtext`).

--- a/skills/subtext-shared/SKILL.md
+++ b/skills/subtext-shared/SKILL.md
@@ -16,7 +16,7 @@ All tools are served from the **subtext** MCP server. A **subtext-eu1** variant 
 | Prefix | Tools |
 |--------|-------|
 | `review-` | Session replay: `review-open`, `review-view`, `review-inspect`, `review-diff`, `review-close` |
-| `privacy-` | Privacy rules: `privacy-propose`, `privacy-create`, `privacy-list`, `privacy-delete`, `privacy-promote` |
+| `privacy-` | Privacy rules: `privacy-propose`, `privacy-create`, `privacy-list`, `privacy-delete`, `privacy-promote`, `privacy-url-list`, `privacy-url-create`, `privacy-network-list`, `privacy-network-create` |
 
 ## Discovering MCP Tool Parameters
 
@@ -25,5 +25,5 @@ Each MCP tool is self-describing. If you're unsure about parameters, the tool's 
 ## Security Rules
 
 - Never expose API tokens, session tokens, or credentials in output.
-- Confirm with the user before any write operation that modifies org configuration (e.g. `privacy-promote`, `privacy-create`).
+- Confirm with the user before any write operation that modifies org configuration (e.g. `privacy-promote`, `privacy-create`, `privacy-url-create`, `privacy-network-create`).
 - Session URLs may contain sensitive user data — don't log or repeat them unnecessarily.

--- a/skills/subtext-using-subtext/SKILL.md
+++ b/skills/subtext-using-subtext/SKILL.md
@@ -13,9 +13,9 @@ This plugin gives you read-only access to Fullstory session recordings, plus pri
 |--------|-------|
 | You have a session URL / want to know what happened | `subtext-review` |
 | You need the session-replay tool catalog (`review-*`) | `subtext-session` |
-| Detect PII or manage element-block privacy rules | `subtext-privacy` |
+| Detect PII or manage element-block, URL, or network privacy rules | `subtext-privacy` |
 
 ## Notes
 
-- Everything here is read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete`, which modify org privacy rules — confirm with the user first.
+- Everything here is read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete` / `privacy-url-create` / `privacy-network-create`, which modify org privacy rules — confirm with the user first.
 - This plugin does **not** drive a live browser or capture before/after proof of code changes. That lives in the separate **Subtext Verify** plugin.


### PR DESCRIPTION
## Summary
- Adds `privacy-url-list`, `privacy-url-create`, `privacy-network-list`, `privacy-network-create` to the `subtext-privacy` skill, documenting new MCP tools that manage URL privacy rules (scrub host/path/query) and network privacy rules (elide/allowlist request-response bodies) alongside the existing element-block rule tools.
- `privacy-url-create`/`privacy-network-create` double as update: pass `guid` (URL rules) or `overwrite=true` (network rules) to replace an existing rule instead of creating a new one. Unlike element rules, these have no preview/promote scope -- created/updated rules apply to all sessions immediately.
- Updates cross-references in `subtext-shared`, `subtext-using-subtext`, `subtext-setup-plugin`, and the README.
- Adds a changeset (minor bump).

The underlying MCP server implementation lives in the Fullstory monorepo (`fs/services/lidar`) -- this PR only updates the docs/skill content served from this repo. Implementation PR: cowpaths/mn#107150.

All four tools verified end-to-end against a live subtext-local server, including a real rule created against a test app. Full proof document with inlined request/response evidence: https://app.staging.fullstory.com/subtext/o-B55B-na1/docs/lDQYpZfUOBIc