### PR TITLE
Adding telemetry skill

### DIFF
--- a/.changeset/telemetry-skill.md
+++ b/.changeset/telemetry-skill.md
@@ -1,0 +1,9 @@
+---
+"subtext": minor
+---
+
+Add the `subtext-telemetry` skill documenting the new `telemetry-event` MCP tool, which records AI-reported workflow milestones (currently the `onboard` capture-snippet install flow) for funnel analysis and success-rate dashboards.
+
+The skill covers the nine onboarding steps (`start` through `complete`), per-step metadata fields, outcome classifications, and fire-and-forget semantics — a failed telemetry event is a soft failure that must never block or abort the user's workflow.
+
+Cross-references in `subtext-shared`, `subtext-using-subtext`, `subtext-setup-plugin`, and the README were updated to match.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Read-only review of Subtext session recordings, plus privacy-rule management, fo
 
 This plugin bundles:
 
-- **Skills** — `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules), plus `subtext-shared` and `subtext-using-subtext`.
+- **Skills** — `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules), `subtext-telemetry` (workflow milestone logging), plus `subtext-shared` and `subtext-using-subtext`.
 - **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1 mirror: `https://api.eu1.fullstory.com/mcp/subtext`). HTTP only — no local process required.
 
 ## Install

--- a/skills/subtext-setup-plugin/SKILL.md
+++ b/skills/subtext-setup-plugin/SKILL.md
@@ -46,5 +46,5 @@ Re-run the connectivity check after authenticating.
 
 After setup, explain what was installed:
 
-- **Skills** — `subtext-review` (structured summary of a session), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules).
+- **Skills** — `subtext-review` (structured summary of a session), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules), `subtext-telemetry` (workflow milestone logging).
 - **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1: `https://api.eu1.fullstory.com/mcp/subtext`).

--- a/skills/subtext-shared/SKILL.md
+++ b/skills/subtext-shared/SKILL.md
@@ -17,6 +17,7 @@ All tools are served from the **subtext** MCP server. A **subtext-eu1** variant 
 |--------|-------|
 | `review-` | Session replay: `review-open`, `review-view`, `review-inspect`, `review-diff`, `review-close` |
 | `privacy-` | Privacy rules: `privacy-propose`, `privacy-create`, `privacy-list`, `privacy-delete`, `privacy-promote`, `privacy-url-list`, `privacy-url-create`, `privacy-network-list`, `privacy-network-create` |
+| `telemetry-` | Workflow telemetry: `telemetry-event` |
 
 ## Discovering MCP Tool Parameters
 

--- a/skills/subtext-telemetry/SKILL.md
+++ b/skills/subtext-telemetry/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: subtext-telemetry
+description: Workflow telemetry logging — record AI-reported workflow milestones (currently the onboarding flow) for funnel analysis. Use when executing an instrumented Subtext workflow and you need to log step-by-step progress events.
+---
+
+# Telemetry
+
+> **PREREQUISITE:** Read `subtext-shared` for MCP conventions.
+
+The telemetry tool records workflow milestones to Fullstory's analytics backend (BigQuery) for funnel analysis and success-rate dashboards. It writes analytics events only — it never modifies application data or org configuration.
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `telemetry-event` | Log one workflow milestone: a `workflow` + `step`, an optional `outcome`, and optional step-specific `metadata`. |
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workflow` | yes | Workflow name. Currently only `onboard` (the Subtext capture-snippet install flow) is supported. |
+| `step` | yes | Milestone within the workflow. For `onboard`, in order: `start`, `precheck`, `explore`, `plan`, `install`, `identify`, `link_analytics`, `mask_pii`, `complete`. |
+| `outcome` | no | `success`, `partial`, `fail`, or `skipped`. Omit for in-progress milestones. |
+| `metadata` | no | A JSON **object** (not an array or scalar) of step-specific fields — see below. |
+
+## Metadata fields by step
+
+Every step's metadata may include `duration_ms` (int) and `tokens` (int). Additional fields vary by step:
+
+| Step | Extra fields |
+|------|--------------|
+| `start` | `harness` (string), `model` (string) |
+| `precheck` | `already_installed` (bool) |
+| `explore` | `framework` (string), `csp_present` (bool) |
+| `plan` | `approved` (bool) |
+| `install` | `framework` (string), `csp_modified` (bool) |
+| `identify` | `identity_added` (bool) |
+| `link_analytics` | `analytics_providers` (string[]) — names of every analytics / session-replay / error-monitoring / feature-flag SDK found installed, e.g. `["posthog", "segment", "sentry"]` |
+| `mask_pii` | `masked_count` (int), `privacy_check` (bool) |
+| `complete` | `total_duration_ms` (int), `total_tokens` (int) |
+
+Unknown metadata fields are tolerated (ignored, not errors), but stick to the documented fields — only they land in typed columns for analysis.
+
+## Typical flow
+
+Log an event at each milestone as you execute the workflow, not retroactively at the end:
+
+```
+telemetry-event workflow="onboard" step="start" metadata={"harness": "claude-code", "model": "claude-fable-5"}
+...
+telemetry-event workflow="onboard" step="install" outcome="success" metadata={"framework": "nextjs", "csp_modified": false, "duration_ms": 42000}
+...
+telemetry-event workflow="onboard" step="complete" outcome="success" metadata={"total_duration_ms": 310000, "total_tokens": 85000}
+```
+
+The response is `{"logged": true}` on success or `{"logged": false, "reason": "..."}` on a soft failure.
+
+## Rules and constraints
+
+- **Fire-and-forget.** A `{"logged": false, ...}` response is a soft failure — note it and move on. Never retry in a loop, and never block or abort the user's workflow because telemetry failed.
+- Org and user identity are attached server-side from the authenticated MCP session — don't put emails, org IDs, or other identifying data in `metadata`.
+- Don't put secrets, tokens, file contents, or free-form user data in `metadata` — only the documented derived fields.
+- `outcome` is a classification of the step, not a log level: use `skipped` when a step didn't apply, `partial` when it half-worked, and omit it entirely for a step that's still in progress.
+- Only log events for workflows you are actually executing. The tool exists to measure real funnels — don't emit synthetic or exploratory events against a production org.
+
+## Gotchas
+
+- Passing `metadata` as anything other than a JSON object — arrays, strings, and scalars are rejected with `{"logged": false}`.
+- Inventing workflow or step names — only `onboard` and its nine documented steps are recognized. New workflows require backend support first.
+- Logging every step at the end of the workflow with made-up durations — log each milestone as it happens so `duration_ms` and failure points are real.
+- Treating a soft failure as an error worth surfacing to the user — telemetry is invisible plumbing; a failed event is at most a one-line note.
+
+## See Also
+
+- `subtext-shared` — MCP conventions

--- a/skills/subtext-using-subtext/SKILL.md
+++ b/skills/subtext-using-subtext/SKILL.md
@@ -14,8 +14,9 @@ This plugin gives you read-only access to Fullstory session recordings, plus pri
 | You have a session URL / want to know what happened | `subtext-review` |
 | You need the session-replay tool catalog (`review-*`) | `subtext-session` |
 | Detect PII or manage element-block, URL, or network privacy rules | `subtext-privacy` |
+| Log workflow milestones (e.g. onboarding progress) for analytics | `subtext-telemetry` |
 
 ## Notes
 
-- Everything here is read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete` / `privacy-url-create` / `privacy-network-create`, which modify org privacy rules — confirm with the user first.
+- Everything here is read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete` / `privacy-url-create` / `privacy-network-create`, which modify org privacy rules — confirm with the user first. (`telemetry-event` writes analytics events only, never org configuration — no confirmation needed.)
 - This plugin does **not** drive a live browser or capture before/after proof of code changes. That lives in the separate **Subtext Verify** plugin.


### PR DESCRIPTION
Summary

Adds a new subtext-telemetry skill documenting the telemetry-event MCP tool recently added to the subtext MCP server (mn 438d35a2e0f). The tool records AI-reported workflow milestones to BigQuery for funnel analysis and success-rate dashboards — currently scoped to the onboard capture-snippet install flow.

What's in the skill

- Tool catalog and parameters — workflow (only onboard today), step (nine milestones: start, precheck, explore, plan, install, identify, link_analytics, mask_pii, complete), optional outcome (success/partial/fail/skipped), and a JSON metadata object.
- Per-step metadata reference — the typed fields each step accepts (e.g. harness/model on start, framework/csp_modified on install, analytics_providers on link_analytics), so events land in typed BigQuery columns rather than being dropped.
- Behavioral guidance — log milestones as they happen rather than retroactively with invented durations; treat {"logged": false} as a fire-and-forget soft failure that never blocks or aborts the user's workflow; keep secrets and identifying data out of metadata (org and user identity are attached server-side).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application logic modifications.
> 
> **Overview**
> Adds **`subtext-telemetry`**, a new agent skill that documents how to use the **`telemetry-event`** MCP tool for workflow funnel logging (today: the **`onboard`** capture-snippet install flow).
> 
> The skill defines the nine onboarding steps, per-step **`metadata`** fields (so events map to typed analytics columns), **`outcome`** values, and **fire-and-forget** behavior when logging fails. **`subtext-shared`** gains a **`telemetry-`** tool prefix row; **`subtext-using-subtext`**, **`subtext-setup-plugin`**, and the **README** list the skill and clarify that telemetry is analytics-only (not org config). A **minor** changeset entry records the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1417693d5867ff66e67e51bd37d32768060d38ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->