### PR TITLE
docs: rewrite session-review skills for the zoom/map/snapshot tool surface

### DIFF
--- a/.changeset/subtext-zoom-review-docs.md
+++ b/.changeset/subtext-zoom-review-docs.md
@@ -1,0 +1,9 @@
+---
+"subtext": minor
+---
+
+Rewrite `subtext-session` and `subtext-review` for the new review tool surface: `review-list-sessions`, `review-open`, `review-summary`, `review-zoom`, `review-snapshot`, and `review-close` replace `review-open`/`review-view`/`review-inspect`/`review-diff`/`review-close`.
+
+Every session open returns a map — signal counts by kind/tag, page flow, and a density strip — that stays whole regardless of what you later zoom into. `review-zoom` takes a `resolution` allow-list (`{scope|kind|tag: grain}`, grains `digest`/`standard`/`machine`/`detail`, finest-wins) for progressive disclosure over the signal stream. `review-snapshot` replaces `review-view`/`review-inspect` for a screen at a moment (screenshot + component tree + boxes, rooted at an optional `component_id`).
+
+`subtext-shared`'s tool prefix table was updated to match.

--- a/skills/subtext-review/SKILL.md
+++ b/skills/subtext-review/SKILL.md
@@ -25,7 +25,7 @@ Review a completed session and produce a structured summary of what happened. Op
 
 ### Step 1: Open the session
 
-Call `review-open` with whichever identifier you have — see `subtext-session` for the five accepted forms. Capture the `client_id` from the response, and read the **map** it returns — signal counts by kind/tag and page flow. Don't call `review-zoom` yet.
+Call `review-open` with whichever identifier you have — see `subtext-session` for the six accepted forms. Capture the `client_id` from the response, and read the **map** it returns — signal counts by kind/tag and page flow. Don't call `review-zoom` yet.
 
 ### Step 2: Form hypotheses from the map
 

--- a/skills/subtext-review/SKILL.md
+++ b/skills/subtext-review/SKILL.md
@@ -25,19 +25,27 @@ Review a completed session and produce a structured summary of what happened. Op
 
 ### Step 1: Open the session
 
-Call `review-open` with whichever identifier you have — see `subtext-session` for the five accepted forms. Capture the `trace_id` from the response.
+Call `review-open` with whichever identifier you have — see `subtext-session` for the five accepted forms. Capture the `client_id` from the response, and read the **map** it returns — signal counts by kind/tag, page flow, and a density strip with error markers. Don't call `review-zoom` yet.
 
-### Step 2: Read the session content
+### Step 2: Form hypotheses from the map
 
-Use `review-view` at key timestamps. Prioritize in this order:
+The map is the orientation layer. Before zooming, ask: does anything in `kinds`/`tags` stand out (an `error:` count, an unusually dense phase)? Where does the density strip's `hot:` callout point? Form one or two hypotheses about what happened — that's what you zoom to confirm.
 
-1. **Errors** — use `review-inspect` or console / network lookups for failure moments.
-2. **Navigation inflections** — page changes, route transitions, modals.
-3. **Before/after pairs** — `review-diff` between two anchor points is the most revealing read.
+### Step 3: Zoom to confirm — as recipes, coarse to fine
 
-Don't sweep the entire session frame-by-frame — that's expensive and usually unnecessary. Lead with the event summaries from `review-open` and the errors within them.
+Use `review-zoom` with a `resolution` map. Treat resolutions as recipes, not parameters to memorize:
 
-### Step 3: Assess
+- Errors anywhere → `resolution={ error: "standard" }`
+- What happened overall → `resolution={ navigation: "standard", interaction: "standard" }`
+- Devtool-level detail on a suspect window → `resolution={ network: "machine", console: "machine" }`, narrowed with `t0_ms`/`t1_ms`
+
+Start coarse (`standard`, the default) and only reach for `machine`/`detail` on the specific kind or tag your hypothesis needs — each step down costs more tokens for more fidelity. Judge coverage against the map from `review-open` (its `kinds`/`tags` counts and density strip); `review-zoom` returns the signal slice.
+
+When you need to see the screen itself — confirm a layout, grab a component tree — use `review-snapshot` at the timestamp in question. It's a separate data set from signals; don't expect it to carry network/console detail.
+
+Don't sweep the entire session frame-by-frame — that's expensive and usually unnecessary. Lead with the map and the errors it surfaces.
+
+### Step 4: Assess
 
 Form a judgment on:
 
@@ -45,7 +53,7 @@ Form a judgment on:
 - **Did it succeed** — any errors? Did the final state match the apparent intent?
 - **Notable moments** — anything surprising, confusing, or worth flagging to the user.
 
-### Step 4: Produce the structured summary
+### Step 5: Produce the structured summary
 
 Output in this shape — stable sections make the result easy to consume, especially for a downstream agent:
 
@@ -69,7 +77,7 @@ Output in this shape — stable sections make the result easy to consume, especi
 <One paragraph. Did the session achieve its apparent goal? Anything the next reader should know?>
 ```
 
-### Step 5: Reproduction steps — only if asked
+### Step 6: Reproduction steps — only if asked
 
 If the user explicitly asks to reproduce, append a structured step list. **Do not execute** — this plugin is read-only. Executing a repro requires driving a live browser, which lives in the separate Subtext Verify plugin.
 
@@ -91,5 +99,5 @@ Always lead with errors. A downstream reader — human or agent — will look fo
 
 ### Repro steps requested
 
-- "reproduce", "repro", "walk me through step by step", "how do I hit this" → produce the step list in Step 5.
-- "review", "summarize", "what happened" → stop at Step 4. Don't volunteer repro steps; they add length without being asked for.
+- "reproduce", "repro", "walk me through step by step", "how do I hit this" → produce the step list in Step 6.
+- "review", "summarize", "what happened" → stop at Step 5. Don't volunteer repro steps; they add length without being asked for.

--- a/skills/subtext-review/SKILL.md
+++ b/skills/subtext-review/SKILL.md
@@ -25,11 +25,11 @@ Review a completed session and produce a structured summary of what happened. Op
 
 ### Step 1: Open the session
 
-Call `review-open` with whichever identifier you have — see `subtext-session` for the five accepted forms. Capture the `client_id` from the response, and read the **map** it returns — signal counts by kind/tag, page flow, and a density strip with error markers. Don't call `review-zoom` yet.
+Call `review-open` with whichever identifier you have — see `subtext-session` for the five accepted forms. Capture the `client_id` from the response, and read the **map** it returns — signal counts by kind/tag and page flow. Don't call `review-zoom` yet.
 
 ### Step 2: Form hypotheses from the map
 
-The map is the orientation layer. Before zooming, ask: does anything in `kinds`/`tags` stand out (an `error:` count, an unusually dense phase)? Where does the density strip's `hot:` callout point? Form one or two hypotheses about what happened — that's what you zoom to confirm.
+The map is the orientation layer. Before zooming, ask: does anything in `kinds`/`tags` stand out (an `error:` count, an unusually dense phase)? Form one or two hypotheses about what happened — that's what you zoom to confirm.
 
 ### Step 3: Zoom to confirm — as recipes, coarse to fine
 
@@ -39,7 +39,7 @@ Use `review-zoom` with a `resolution` map. Treat resolutions as recipes, not par
 - What happened overall → `resolution={ navigation: "standard", interaction: "standard" }`
 - Devtool-level detail on a suspect window → `resolution={ network: "machine", console: "machine" }`, narrowed with `t0_ms`/`t1_ms`
 
-Start coarse (`standard`, the default) and only reach for `machine`/`detail` on the specific kind or tag your hypothesis needs — each step down costs more tokens for more fidelity. Judge coverage against the map from `review-open` (its `kinds`/`tags` counts and density strip); `review-zoom` returns the signal slice.
+Start coarse (`standard`, the default) and only reach for `machine`/`detail` on the specific kind or tag your hypothesis needs — each step down costs more tokens for more fidelity. Judge coverage against the map from `review-open` (its `kinds`/`tags` counts); `review-zoom` returns the signal slice.
 
 When you need to see the screen itself — confirm a layout, grab a component tree — use `review-snapshot` at the timestamp in question. It's a separate data set from signals; don't expect it to carry network/console detail.
 

--- a/skills/subtext-session/SKILL.md
+++ b/skills/subtext-session/SKILL.md
@@ -7,17 +7,18 @@ description: Session replay tools for analyzing Fullstory session recordings. Sp
 
 > **PREREQUISITE:** Read `subtext-shared` for MCP conventions.
 
-API catalog for the session replay tools (all prefixed `review-`). These tools let you open sessions, inspect UI state at specific timestamps, and compare state across time.
+API catalog for the session replay tools (all prefixed `review-`). One gesture — **zoom** — over two data sets: the **signal stream** (temporal) and the **snapshot** (spatial). Opening a session hands back a **map**: an always-on orientation header, never a zoom level.
 
 ## MCP Tools
 
 | Tool | Description |
 |------|-------------|
-| `review-open` | Open a session for analysis. Returns event summaries, metadata, timestamps. |
-| `review-view` | Capture UI state at a timestamp — component tree + screenshot. Pass `component_id` to clip to a specific element's bounding box; optional `expand_pct` (0–100) grows the clip rect outward for surrounding context, clamped to the viewport. |
-| `review-inspect` | Component tree with full CSS selectors — for detailed element inspection, not general use. |
-| `review-diff` | Compare UI state between two timestamps. |
-| `review-close` | Close the session and free resources. |
+| `review-list-sessions` | Find reviewable sessions — numbered URLs + timestamps. |
+| `review-open` | Open a session for analysis. Returns a handle (`client_id`) plus the **map** — not the signal flood. |
+| `review-summary` | Static "what happened" — map + the default zoom (all kinds @ `standard`), frozen. Stateless, no handle, cheapest call. Use for a quick read before deciding whether to `open`. |
+| `review-zoom` | The live lens. Pass a `resolution` map and/or a `t0_ms`/`t1_ms` time window — returns the matching signal slice. |
+| `review-snapshot` | The screen at a moment — screenshot + component tree + boxes, rooted at an optional `component_id`. |
+| `review-close` | Close the session and free resources; records a short usage summary. |
 
 ## Discovering Parameters
 
@@ -32,14 +33,80 @@ Parameter schemas are visible in the tool definition at call time.
 - `device_id` + `session_id` — both required together. Use when you have the raw ids but no URL.
 - `email_address` / `user_uid` — looks up the user's most recent session.
 
-All five paths return the same trace_id-keyed handle; the entry point doesn't change what comes out. Capture the `trace_id` from the response so follow-on calls don't need to re-resolve the session.
+All five paths return the same handle. Capture the `client_id` from the response so follow-on `review-zoom`/`review-snapshot`/`review-close` calls don't need to re-resolve the session.
+
+## The map
+
+`review-open` and `review-summary` responses include a map — a cheap counting fold over the signal layer, never a body dump:
+
+```
+## Map · 114 signals · 0.0s–353s · 2 pages
+flow: /ui ▸ /settings/overview ▸ /subtext/sessions ▸ /subtext/session/asr
+kinds: navigation 18 · interaction 36 · network 58 (2 err) · console 2 (2 err)
+tags: error:4
+```
+
+The map is **whole** — rendered once, over the entire session. Zooming into `{navigation: "standard"}` later doesn't touch it: `error:4` stays in the map's counts regardless of what you go on to zoom into. Read the map first; it tells you what exists and roughly where (`hot:` callouts point at the busiest/erroring range) before you pay for a zoom.
+
+## The resolution contract
+
+`review-zoom` takes:
+
+```
+resolution?: { [scope | kind | tag]: "digest" | "standard" | "machine" | "detail" }
+t0_ms?: number   // narrow the zoom to a time window
+t1_ms?: number
+```
+
+Grain ladder, coarse → fine:
+
+| grain | what you see |
+|-------|--------------|
+| `digest` | one rollup line per (section × kind) — `network ×19 (1 err)` |
+| `standard` *(default)* | the readable transcript — bursty/repeated signals merged into one line |
+| `machine` | every signal, nothing merged |
+| `detail` | every signal plus its payload — headers, bodies, stack traces |
+
+- **Omit `resolution`** → everything at `standard`.
+- **Provide it** → an explicit allow-list. Unlisted kinds are excluded from the slice (never from the map).
+- **Overlap → finest-wins.** A signal matching more than one key takes the finest grain among them — order-independent, and it can only ever show *more*, never hide something.
+
+Keys are scopes (`navigation`, `interaction`, `network`, `console`, …), kinds (`click`, `network`, `exception`, …), or tags (`error`, `exception` — the only tags today) — they resolve the same way.
+
+### Zoom recipes
+
+```
+// what went wrong, anywhere
+review-zoom resolution={ error: "standard" }
+
+// what happened in this session
+review-zoom resolution={ navigation: "standard", interaction: "standard" }
+
+// devtool-level detail
+review-zoom resolution={ network: "machine", console: "machine" }
+
+// network readable, but every error deep — finest-wins, no override needed
+review-zoom resolution={ network: "standard", error: "detail" }
+```
+
+## Snapshot
+
+`review-snapshot` takes `client_id` + `timestamp`, plus:
+
+- `component_id` — optional; roots **both** the image clip and the tree subtree, so "focus here" means one thing.
+- `lens` — `visible` (default), `interactive`, or `full`. Governs which elements populate the tree/boxes, not the pixels.
+- `include` — any of `image`, `tree`, `boxes`.
+- `expand_pct` — grows the `component_id` clip outward by this percent (0–100) for surrounding context.
+- `upload` — store the screenshot and return a shareable signed URL.
+
+No network/console excerpts are stapled onto a snapshot — signals only come from `review-zoom`. Want the requests or logs around a moment? Zoom that window.
 
 ## Tips
 
-- Event summaries from `review-open` are cheap. `review-view` is expensive. Start with summaries.
-- When investigating a single suspect element, clip with `component_id` (and a small `expand_pct` for context). Smaller payload, sharper evidence.
-- `review-diff` between two moments is the most revealing tool — it shows exactly what changed.
-- Console errors and network failures in event summaries are highest-signal starting points.
+- Read the map before you zoom. It's free and tells you whether there's anything worth looking at, and roughly where.
+- Start every zoom at `standard` (or omit `resolution` entirely) unless you already have a hypothesis about which kind matters.
+- `error` as a resolution key is a floor, not a special case — it only ever raises detail wherever it applies.
+- Use `review-snapshot` for "what did the screen look like," not for signals — it's a different data set.
 - Always close sessions when done to free server resources.
 
 ## See Also

--- a/skills/subtext-session/SKILL.md
+++ b/skills/subtext-session/SKILL.md
@@ -14,7 +14,7 @@ API catalog for the session replay tools (all prefixed `review-`). One gesture �
 | Tool | Description |
 |------|-------------|
 | `review-list-sessions` | Find reviewable sessions — numbered URLs + timestamps. |
-| `review-open` | Open a session for analysis. Returns a handle (`client_id`) plus the **map** — not the signal flood. |
+| `review-open` | Open a session for analysis. Returns a handle (`client_id`) plus the **map** and a digest rollup. |
 | `review-summary` | Static "what happened" — the default zoom (all kinds @ `standard`), frozen. No map, no handle. Stateless, cheapest call. Use for a quick read before deciding whether to `open`. |
 | `review-zoom` | The live lens. Pass a `resolution` map and/or a `t0_ms`/`t1_ms` time window — returns the matching signal slice. |
 | `review-snapshot` | The screen at a moment — screenshot + component tree + boxes, rooted at an optional `component_id`. |
@@ -26,14 +26,15 @@ Parameter schemas are visible in the tool definition at call time.
 
 ## Session Input
 
-`review-open` accepts five mutually-exclusive identifiers. Pick the one that matches what you have on hand — they're all first-class:
+`review-open` accepts six mutually-exclusive identifiers. Pick the one that matches what you have on hand — they're all first-class:
 
+- `session_url` — a full Fullstory session URL. The most common form — a customer-shared link, a Slack paste, or a session from the app UI.
 - `trace_id` — the 12-char base62 id from a prior `review-open` response.
-- `session_url` — a full Fullstory session URL (a customer-shared link, a Slack paste, or a session from the app UI).
+- `trace_url` — a full trace URL copied from the browser or returned by a live tool.
 - `device_id` + `session_id` — both required together. Use when you have the raw ids but no URL.
 - `email_address` / `user_uid` — looks up the user's most recent session.
 
-All five paths return the same handle. Capture the `client_id` from the response so follow-on `review-zoom`/`review-snapshot`/`review-close` calls don't need to re-resolve the session.
+All six paths return the same handle. Capture the `client_id` from the response so follow-on `review-zoom`/`review-snapshot`/`review-close` calls don't need to re-resolve the session.
 
 ## The map
 

--- a/skills/subtext-session/SKILL.md
+++ b/skills/subtext-session/SKILL.md
@@ -46,7 +46,7 @@ kinds: navigation 18 · interaction 36 · network 58 (2 err) · console 2 (2 err
 tags: error:4
 ```
 
-The map is **whole** — rendered once, over the entire session. Zooming into `{navigation: "standard"}` later doesn't touch it: `error:4` stays in the map's counts regardless of what you go on to zoom into. Read the map first; it tells you what exists and roughly where (`hot:` callouts point at the busiest/erroring range) before you pay for a zoom.
+The map is **whole** — rendered once, over the entire session. Zooming into `{navigation: "standard"}` later doesn't touch it: `error:4` stays in the map's counts regardless of what you go on to zoom into. Read the map first; it tells you what exists before you pay for a zoom.
 
 ## The resolution contract
 

--- a/skills/subtext-session/SKILL.md
+++ b/skills/subtext-session/SKILL.md
@@ -15,7 +15,7 @@ API catalog for the session replay tools (all prefixed `review-`). One gesture �
 |------|-------------|
 | `review-list-sessions` | Find reviewable sessions — numbered URLs + timestamps. |
 | `review-open` | Open a session for analysis. Returns a handle (`client_id`) plus the **map** — not the signal flood. |
-| `review-summary` | Static "what happened" — map + the default zoom (all kinds @ `standard`), frozen. Stateless, no handle, cheapest call. Use for a quick read before deciding whether to `open`. |
+| `review-summary` | Static "what happened" — the default zoom (all kinds @ `standard`), frozen. No map, no handle. Stateless, cheapest call. Use for a quick read before deciding whether to `open`. |
 | `review-zoom` | The live lens. Pass a `resolution` map and/or a `t0_ms`/`t1_ms` time window — returns the matching signal slice. |
 | `review-snapshot` | The screen at a moment — screenshot + component tree + boxes, rooted at an optional `component_id`. |
 | `review-close` | Close the session and free resources; records a short usage summary. |
@@ -37,7 +37,7 @@ All five paths return the same handle. Capture the `client_id` from the response
 
 ## The map
 
-`review-open` and `review-summary` responses include a map — a cheap counting fold over the signal layer, never a body dump:
+`review-open`'s response includes a map — a cheap counting fold over the signal layer, never a body dump:
 
 ```
 ## Map · 114 signals · 0.0s–353s · 2 pages
@@ -103,7 +103,7 @@ No network/console excerpts are stapled onto a snapshot — signals only come fr
 
 ## Tips
 
-- Read the map before you zoom. It's free and tells you whether there's anything worth looking at, and roughly where.
+- Read the map before you zoom. It's free and tells you whether there's anything worth looking at.
 - Start every zoom at `standard` (or omit `resolution` entirely) unless you already have a hypothesis about which kind matters.
 - `error` as a resolution key is a floor, not a special case — it only ever raises detail wherever it applies.
 - Use `review-snapshot` for "what did the screen look like," not for signals — it's a different data set.

--- a/skills/subtext-shared/SKILL.md
+++ b/skills/subtext-shared/SKILL.md
@@ -15,7 +15,7 @@ All tools are served from the **subtext** MCP server. A **subtext-eu1** variant 
 
 | Prefix | Tools |
 |--------|-------|
-| `review-` | Session replay: `review-open`, `review-view`, `review-inspect`, `review-diff`, `review-close` |
+| `review-` | Session replay: `review-list-sessions`, `review-open`, `review-summary`, `review-zoom`, `review-snapshot`, `review-close` |
 | `privacy-` | Privacy rules: `privacy-propose`, `privacy-create`, `privacy-list`, `privacy-delete`, `privacy-promote`, `privacy-url-list`, `privacy-url-create`, `privacy-network-list`, `privacy-network-create` |
 
 ## Discovering MCP Tool Parameters


### PR DESCRIPTION
## Summary
- Rewrites `subtext-session` and `subtext-review` for the new review tool surface: `review-list-sessions`, `review-open`, `review-summary`, `review-zoom`, `review-snapshot`, and `review-close` replace `review-open`/`review-view`/`review-inspect`/`review-diff`/`review-close`.
- Every session open returns a map (signal counts, page flow, density strip) that stays whole regardless of what's later zoomed into.
- `review-zoom` takes a `resolution` allow-list (`{scope|kind|tag: grain}`, grains `digest`/`standard`/`machine`/`detail`, finest-wins) for progressive disclosure over the signal stream.
- `review-snapshot` replaces `review-view`/`review-inspect` for a screen at a moment (screenshot + component tree + boxes, rooted at an optional `component_id`).
- `subtext-shared`'s tool prefix table updated to match. Changeset included.
