### PR TITLE
docs: make README a front door for wizard-first onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Subtext, by Fullstory
 
-**Session replay, built for agents.** Subtext is agentic session review: it captures Fullstory session recordings of your app and connects them to your coding agent — Claude Code, Cursor, Codex, or Gemini CLI — so it can review what real users did, reproduce reported bugs, verify its own UI changes, and manage capture privacy rules, all without leaving the terminal.
+**Session replay, built for agents.** Subtext is agentic session review: it captures production sessions of your app and connects them to your coding agent — Claude Code, Cursor, Codex, or Gemini CLI — so it can review what real users did, reproduce reported bugs, verify its own UI changes, and manage capture privacy rules, all without leaving the terminal.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Get started
 
-The fastest way in is the setup wizard. Run it in your project directory:
+The fastest way in is the [setup wizard](https://github.com/fullstorydev/subtext-wizard). Run it in your project directory:
 
 ```sh
 npx @subtextdev/subtext-wizard

--- a/README.md
+++ b/README.md
@@ -1,36 +1,66 @@
 # Subtext, by Fullstory
 
-Read-only review of Subtext session recordings, plus privacy-rule management, for coding agents.
+**Give your coding agent eyes on real usage.** Subtext captures Fullstory session recordings of your app and connects them to your coding agent — Claude Code, Cursor, Codex, or Gemini CLI — so it can review what real users did, reproduce reported bugs, verify its own UI changes, and manage capture privacy rules, all without leaving the terminal.
 
-This plugin bundles:
+## Get started
 
-- **Skills** — `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules), `subtext-telemetry` (workflow milestone logging), plus `subtext-shared` and `subtext-using-subtext`.
-- **MCP server** — `subtext` at `https://api.fullstory.com/mcp/subtext` (EU1 mirror: `https://api.eu1.fullstory.com/mcp/subtext`). HTTP only — no local process required.
+The fastest way in is the setup wizard. Run it in your project directory:
 
-## Install
+```sh
+npx @subtextdev/subtext-wizard
+```
 
-**Claude Code**
+One command handles the whole setup: it logs you in, fetches your org's capture snippet, asks which analytics tools you use, then hands the install off to your own coding agent — which wires up the capture snippet, MCP server, skills, and commands for you. Takes a few minutes.
+
+**Requires a free Subtext account — no credit card.** Subtext is hosted: your app's sessions are recorded to the cloud so your agent can read them back through the MCP server — that's what the account is for. The wizard handles it. When it opens the login page, create an account in one click with Google, then come back to finish.
+
+_EU data region? Run `npx @subtextdev/subtext-wizard --region eu`._
+
+## What you get
+
+Once setup is done, your agent has these tools:
+
+- **Session review** — point your agent at a recorded session and it walks through what happened: the flow the user took, console errors, network activity, and where things broke. Great for debugging user-reported issues or confirming a fix landed in the real UI.
+- **Privacy rules** — detect PII in captured sessions and manage element-block, URL, and network capture rules directly from your agent.
+
+Driving a *live* browser and capturing before/after proof of code changes live in the companion **[Subtext Verify](https://github.com/fullstorydev/subtext-verify)** plugin.
+
+## Set up manually
+
+Prefer to wire things up yourself? The wizard just automates the steps below — you can do them by hand instead.
+
+**1. Install the plugin**
+
+_Claude Code_
 ```
 /plugin marketplace add fullstorydev/subtext
 /plugin install subtext@subtext-marketplace
 ```
 
-**Cursor** — install from the Marketplace panel (or a Team Marketplace that imports this repo).
+_Cursor_ — install from the Marketplace panel (or a Team Marketplace that imports this repo).
 
-**Codex** — open `/plugins`, install **subtext** from the repo marketplace.
+_Codex_ — open `/plugins`, install **subtext** from the repo marketplace.
 
-**Gemini CLI**
+_Gemini CLI_
 ```
 gemini extensions install https://github.com/fullstorydev/subtext
 ```
 
-**Manual / openskills**
+_Manual / openskills_
 ```
 npx openskills install fullstorydev/subtext
 ```
-…then add the `subtext` MCP server (URL above) to your agent's MCP configuration.
+…then add the `subtext` MCP server (below) to your agent's MCP configuration.
+
+**2. Connect the MCP server**
+
+The `subtext` server runs at `https://api.fullstory.com/mcp/subtext` (EU1 mirror: `https://api.eu1.fullstory.com/mcp/subtext`). It's HTTP only — no local process required.
+
+**3. Add the capture snippet to your app**
+
+Install the Fullstory capture snippet for your org so sessions are recorded. The wizard does this for you against your org's snippet; to do it by hand, grab your snippet from your Fullstory settings.
 
 ## Notes
 
 - All tools are read-only analysis **except** `privacy-create` / `privacy-promote` / `privacy-delete` / `privacy-url-create` / `privacy-network-create`, which modify org privacy rules.
-- Driving a live browser and capturing before/after proof of code changes live in the separate **Subtext Verify** plugin.
+- This plugin bundles the **skills** `subtext-review` (structured session summaries), `subtext-session` (the `review-*` tool catalog), `subtext-privacy` (PII detection + element-block/URL/network privacy rules), and `subtext-telemetry` (workflow milestone logging), plus `subtext-shared` and `subtext-using-subtext`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Subtext, by Fullstory
 
-**Give your coding agent eyes on real usage.** Subtext captures Fullstory session recordings of your app and connects them to your coding agent — Claude Code, Cursor, Codex, or Gemini CLI — so it can review what real users did, reproduce reported bugs, verify its own UI changes, and manage capture privacy rules, all without leaving the terminal.
+**Session replay, built for agents.** Subtext is agentic session review: it captures Fullstory session recordings of your app and connects them to your coding agent — Claude Code, Cursor, Codex, or Gemini CLI — so it can review what real users did, reproduce reported bugs, verify its own UI changes, and manage capture privacy rules, all without leaving the terminal.
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -31,22 +31,22 @@ Prefer to wire things up yourself? The wizard just automates the steps below —
 
 **1. Install the plugin**
 
-_Claude Code_
+**Claude Code**
 ```
 /plugin marketplace add fullstorydev/subtext
 /plugin install subtext@subtext-marketplace
 ```
 
-_Cursor_ — install from the Marketplace panel (or a Team Marketplace that imports this repo).
+**Cursor** — install from the Marketplace panel (or a Team Marketplace that imports this repo).
 
-_Codex_ — open `/plugins`, install **subtext** from the repo marketplace.
+**Codex** — open `/plugins`, install **subtext** from the repo marketplace.
 
-_Gemini CLI_
+**Gemini CLI**
 ```
 gemini extensions install https://github.com/fullstorydev/subtext
 ```
 
-_Manual / openskills_
+**Manual / openskills**
 ```
 npx openskills install fullstorydev/subtext
 ```


### PR DESCRIPTION
## What

Rewrites `README.md` so this repo works as the front-door people land on from the launch post.

- **Leads with the setup wizard** — `npx @subtextdev/subtext-wizard` is now the headline "Get started" action, with a short description of what one command does (login → snippet → integrations → hands off to the user's own agent).
- **Demotes plugin install to "Set up manually"** — framed as automating the wizard's steps. Keeps all existing per-agent install instructions plus the MCP server URL.
- **Adds a tightened "free Subtext account — no credit card" explainer** stating why the hosted account is needed (sessions are recorded to the cloud so the agent can read them back), plus the one-click Google create-then-return flow.
- **New opening one-liner** repositions the repo around the whole product rather than just the read-only review plugin.
- Links the companion **Subtext Verify** plugin.

## Note

The Fullstory onboarding UI showed `npx @subtextdev/subtext-wizard .` (trailing `.`), but the CLI sets `allowPositionals: false`, so that form errors. The README uses the working command (`--dir` already defaults to cwd). Marketing/UI copy is being updated separately to drop the `.`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README rewrite with no runtime, auth, or data-path changes.
> 
> **Overview**
> **Repositions the README** as a launch-post front door with a product-focused opener (“session replay, built for agents”) instead of leading with “read-only review plugin.”
> 
> **Wizard-first onboarding:** New **Get started** section puts `npx @subtextdev/subtext-wizard` first, explains the one-command flow (login → snippet → integrations → agent handoff), free hosted account / Google signup, and EU `--region eu`. **What you get** summarizes session review and privacy tools; **Subtext Verify** is linked for live browser proof.
> 
> **Manual path demoted:** Per-agent plugin install, MCP URLs, and a new **capture snippet** step are grouped under **Set up manually** as the wizard’s hand-done equivalent. **Notes** still call out privacy mutating tools and now list bundled skills there instead of up top.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc6d3de639adf566dc5be1cab7f38f9abd834ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->