### PR TITLE
feat(subtext-sightmap): reinstate sightmap side-band upload path

### DIFF
--- a/.changeset/subtext-sightmap-upload.md
+++ b/.changeset/subtext-sightmap-upload.md
@@ -1,0 +1,5 @@
+---
+"subtext": minor
+---
+
+subtext-sightmap: reinstate the sightmap side-band upload path. The public skills lost the upload workflow when sightmap support was pulled from the initial release; this restores it in the first-party bridge skill. Bundles the `collect_and_upload_sightmap.py` collector beside the skill (referenced skill-relative, no plugin-root variable) and documents `review-open` / `live-connect` / `live-tunnel` → `sightmap_upload_url` → collector (before zoom/snapshot) as the preferred way to feed a `.sightmap/` corpus into a review. The inline `review-open sightmap:` array is demoted to a small, hand-authored / no-Python fallback, with the hierarchical-flatten caveat spelled out.

--- a/skills/subtext-sightmap/SKILL.md
+++ b/skills/subtext-sightmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subtext-sightmap
-description: Connect a project's .sightmap/ corpus to Subtext session review — maintain it with the bundled sightmap skills and pass its definitions into review tools so snapshots come back with semantic component names.
+description: Connect a project's .sightmap/ corpus to Subtext session review — maintain it with the bundled sightmap skills and upload its definitions into review tools so snapshots come back with semantic component names.
 ---
 
 # Subtext × Sightmap
@@ -28,17 +28,51 @@ Both drive the `sightmap` CLI. If it isn't on PATH, install it
 
 ## Feeding the corpus into review
 
-When you have a `.sightmap/` directory, pass its definitions to the session
-tools so their output is enriched:
+When a project has a `.sightmap/` directory, upload it to the session so the
+output is enriched. There are two ways; **prefer the side-band upload** for any
+real corpus.
 
-- `review-open` accepts a `sightmap` array (component definitions: `name`,
-  `selectors`, optional `memory`, `source`) and a top-level `memory` array.
-- Read the project's `.sightmap/` YAML, translate the component definitions into
-  that shape, and pass them through on open.
-- Matched component names then appear in `review-snapshot` component trees, and
-  `memory` entries surface as an orientation guide.
+### Preferred — side-band upload (whole corpus)
 
-Keep the corpus the source of truth: edit `.sightmap/` YAML, then re-pass it —
+`review-open` returns a single-use `sightmap_upload_url` in its response (so do
+the live tools: `live-connect` returns `sightmap_upload_url`, `live-tunnel`
+returns `sightmapUploadUrl`). Upload the checked-in corpus to that URL with the
+bundled collector script **before** you read anything back — before
+`review-zoom` / `review-snapshot` for a review, or before `live-view-new` for the
+tunnel-first live flow:
+
+```bash
+# run from the project root (where .sightmap/ lives):
+python3 <this skill's directory>/collect_and_upload_sightmap.py --url <sightmap_upload_url>
+```
+
+`collect_and_upload_sightmap.py` sits **beside this SKILL.md** — reference it at
+that path (it ships with the skill; there is no plugin-root variable to expand).
+It walks `.sightmap/**/*.yaml` under the project root (auto-detected by walking up
+from the current directory, or pass `--root DIR` / set `SIGHTMAP_ROOT`), flattens
+hierarchical components into the compound selectors the matcher expects, collects
+top-level `memory`, and POSTs the result using the single-use token embedded in
+the URL — no extra auth. Requires **Python 3.9+ and PyYAML** (`pip install pyyaml`).
+
+Matched component names then appear in `review-snapshot` component trees and
+`review-zoom` signals, and `memory` entries surface as an orientation guide.
+
+> **Scope today:** the collector uploads **components** (including view-scoped
+> components) and top-level **memory** only. `requests:` and `views:` definitions
+> are not uploaded yet — network / view-name enrichment isn't wired through the
+> signal stream.
+
+### Fallback — inline on `review-open` (small, hand-authored sets)
+
+For a handful of flat, hand-written definitions — or a harness without Python —
+`review-open` also accepts a `sightmap` array (component definitions: `name`,
+`selectors`, optional `memory`, `source`) and a top-level `memory` array directly.
+
+Reach for this only for tiny sets. The array takes **already-flattened** compound
+selectors, so nested components must be flattened by hand (each parent selector
+prefixed onto its children) — which is exactly what the collector script does for
+you, which is why the side-band upload is preferred for anything real. Either way,
+keep the `.sightmap/` corpus the source of truth: edit the YAML and re-upload —
 don't paste one-off definitions that aren't checked in.
 
 ## See also

--- a/skills/subtext-sightmap/collect_and_upload_sightmap.py
+++ b/skills/subtext-sightmap/collect_and_upload_sightmap.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Collect .sightmap/ definitions and upload them to a Lidar MCP session.
+
+Walks all .sightmap/**/*.yaml files under a given root, parses component definitions, flattens
+hierarchical children into compound CSS selectors suitable for the subtext MCP's NFA matcher, and
+uploads the result to the sightmap upload endpoint.
+
+Usage:
+    python3 collect_and_upload_sightmap.py --url <sightmap_upload_url> [--root DIR]
+
+The upload URL is returned by open_session / open_connection and includes a
+single-use authentication token.
+"""
+
+# Python 3.9 compat
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+try:
+    import yaml  # type: ignore[import-not-found]
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+
+# ---------------------------------------------------------------------------
+# Sightmap collection
+# ---------------------------------------------------------------------------
+
+
+def find_sightmap_files(root: str) -> list[str]:
+    """Find all .yaml/.yml files under root/.sightmap/.
+
+    Checks only the direct .sightmap/ child of root to avoid walking
+    potentially massive directory trees (node_modules, go, etc.).
+    """
+    sdir = os.path.join(root, ".sightmap")
+    if not os.path.isdir(sdir):
+        return []
+
+    files = []
+    for dirpath, _, filenames in os.walk(sdir):
+        for name in sorted(filenames):
+            if name.endswith((".yaml", ".yml")):
+                files.append(os.path.join(dirpath, name))
+    return files
+
+
+def flatten_components(
+    components: list[dict],
+    parent_selectors: Optional[list[str]] = None,
+    parent_source: str = "",
+) -> list[dict]:
+    """Flatten hierarchical component definitions into a flat list.
+
+    Children inherit the parent's selectors as prefixes (descendant combinator)
+    and the parent's source if they don't specify their own.
+
+    The YAML ``selector`` field may be a string or a list of strings. The output
+    always uses ``selectors`` (a JSON array) so the Go side never needs to split
+    comma-separated values.
+    """
+    if parent_selectors is None:
+        parent_selectors = []
+    result = []
+    for comp in components:
+        name = comp.get("name", "")
+        raw = comp.get("selector", "")
+        source = comp.get("source", "") or parent_source
+
+        # Normalise to a list — YAML authors may write a string or a list.
+        if isinstance(raw, list):
+            selectors = [s for s in raw if s]
+        elif raw:
+            selectors = [raw]
+        else:
+            selectors = []
+
+        # Build full selector chains by combining with parent selectors.
+        if parent_selectors and selectors:
+            full_selectors = [f"{p} {s}" for p in parent_selectors for s in selectors]
+        elif parent_selectors:
+            full_selectors = list(parent_selectors)
+        else:
+            full_selectors = selectors
+
+        if name and full_selectors:
+            memory = comp.get("memory", [])
+            if not isinstance(memory, list):
+                memory = [memory] if memory else []
+            entry = {
+                "name": name,
+                "selectors": full_selectors,
+                "source": source or "",
+                "memory": memory,
+            }
+            result.append(entry)
+
+        # Recurse into children
+        children = comp.get("children", [])
+        if children:
+            result.extend(flatten_components(children, full_selectors, source))
+
+    return result
+
+
+def parse_file(path: str) -> list[dict]:
+    """Parse a single sightmap YAML file and return flattened components."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        return []
+
+    components = data.get("components", [])
+    if not isinstance(components, list):
+        components = []
+
+    result = flatten_components(components)
+
+    # Also flatten view-scoped components
+    views = data.get("views", [])
+    if isinstance(views, list):
+        for view in views:
+            view_components = view.get("components", [])
+            if isinstance(view_components, list):
+                result.extend(flatten_components(view_components))
+
+    return result
+
+
+def collect(root: str) -> list[dict]:
+    """Collect all sightmap definitions from a root directory."""
+    files = find_sightmap_files(root)
+    result = []
+    for path in files:
+        result.extend(parse_file(path))
+    return result
+
+
+def collect_memory(root: str) -> list[str]:
+    """Collect top-level memory entries from .sightmap/ YAML files."""
+    files = find_sightmap_files(root)
+    result: list[str] = []
+    for path in files:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            continue
+        memory = data.get("memory", [])
+        if isinstance(memory, str):
+            memory = [memory]
+        if isinstance(memory, list):
+            result.extend(str(m) for m in memory if m)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sightmap root discovery
+# ---------------------------------------------------------------------------
+
+
+def find_sightmap_root(cwd: str) -> Optional[str]:
+    """Find a directory containing .sightmap/, checking cwd and ancestors."""
+    d = cwd
+    while d != os.path.dirname(d):
+        if os.path.isdir(os.path.join(d, ".sightmap")):
+            return d
+        d = os.path.dirname(d)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect and upload .sightmap/ definitions"
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="Sightmap upload URL (from open_session/open_connection response)",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Root directory containing .sightmap/ (auto-detected if omitted)",
+    )
+    args = parser.parse_args()
+
+    root = (
+        args.root or os.environ.get("SIGHTMAP_ROOT") or find_sightmap_root(os.getcwd())
+    )
+    if not root:
+        print("No .sightmap/ directory found", file=sys.stderr)
+        sys.exit(1)
+
+    components = collect(root)
+    memory = collect_memory(root)
+
+    if not components and not memory:
+        print("No sightmap definitions found")
+        sys.exit(0)
+
+    body = json.dumps(
+        {
+            "sightmap": components,
+            "memory": memory,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        args.url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    # Allow self-signed certs for local dev servers (.test, localhost).
+    ssl_ctx = None
+    parsed_url = urllib.parse.urlparse(args.url)
+    if parsed_url.hostname and (
+        parsed_url.hostname.endswith(".test")
+        or parsed_url.hostname in ("localhost", "127.0.0.1")
+    ):
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=ssl_ctx) as resp:
+            result = json.loads(resp.read())
+            count = result.get("components", 0)
+            print(f"Uploaded {count} sightmap component(s)")
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        print(f"Upload failed ({e.code}): {body_text}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Upload failed: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

Sightmap support was pulled from the initial public Subtext release, so the public skills lost the sightmap-upload workflow. The old copies vendored into other repos kept it, which left a split-brain: those describe a side-band upload + collector script, while `subtext-sightmap` here only documented an inline `review-open sightmap:` array — and that array wants **already-flattened** compound selectors, so it silently produces wrong/missing selectors on any hierarchical corpus.

This restores the upload path in the first-party bridge skill (`subtext-sightmap`), which is the right home: `subtext-shared` stays sightmap-agnostic, and `sightmap-authoring`/`sightmap-browser` are vendored (blown away by the `sync-sightmap-skills.mjs` sweep).

## Changes

- **Bundle `collect_and_upload_sightmap.py`** beside `subtext-sightmap/SKILL.md`. It walks `.sightmap/**/*.yaml`, flattens hierarchical components into compound selectors, collects top-level `memory`, and POSTs to the single-use upload URL. Referenced **skill-relative** (no `${CLAUDE_PLUGIN_ROOT}`), and `subtext-` is outside the `sightmap-*` vendor sweep so it's safe here.
- **Rewrite "Feeding the corpus into review"**:
  - Preferred: `review-open` / `live-connect` / `live-tunnel` → `sightmap_upload_url` → run the collector **before** `review-zoom`/`review-snapshot` (or `live-view-new`).
  - Fallback: the inline `sightmap` array, demoted to small hand-authored sets / no-Python harnesses, with the hierarchical-flatten caveat spelled out.
  - Scope note: the collector uploads **components + `memory`** only today; `requests:`/`views:` enrichment isn't wired through the signal stream yet.
- **Changeset** (`minor`).

## Notes / follow-ups

- Requires Python 3.9+ and PyYAML at run time (matches the original implementation).
- The collector's **tests + fixtures were intentionally not ported** — they'd ship pytest fixtures inside the distributed plugin skill dir, and there's no Python test runner here yet. Follow-up: land them in a proper non-shipped location, or fold a generic "extract + upload to URL" subcommand into the `sightmap` CLI and retire the bundled script.

## Test

- `python3 -m py_compile` clean on the ported script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Skill documentation and a bundled client upload script only; no server or auth logic changes in this diff.
> 
> **Overview**
> Restores the **side-band sightmap upload** workflow in the first-party `subtext-sightmap` skill after it was dropped from the public release. Agents are steered to POST the checked-in `.sightmap/` corpus to the single-use `sightmap_upload_url` from `review-open`, `live-connect`, or `live-tunnel` **before** zoom/snapshot (or `live-view-new`), instead of relying on inline `review-open` arrays that need hand-flattened selectors.
> 
> Ships **`collect_and_upload_sightmap.py`** next to `SKILL.md`: it discovers `.sightmap/**/*.yaml`, flattens hierarchical components to compound selectors, gathers top-level `memory`, and POSTs JSON (Python 3.9+ / PyYAML). The skill doc demotes inline `sightmap` to a small no-Python fallback and notes upload scope is **components + memory** only (not `requests`/`views` yet). Minor changeset for `subtext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2a5e31d488e956ed8428d06fcc65eb700b4912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->