### PR TITLE
fix(subtext-sightmap): drop live/tunnel refs from upload instructions

### DIFF
--- a/.changeset/sightmap-strip-live-refs.md
+++ b/.changeset/sightmap-strip-live-refs.md
@@ -1,0 +1,11 @@
+---
+"subtext": patch
+---
+
+subtext-sightmap: remove references to live-mode tools from the sightmap upload
+instructions. The bridge skill documented `live-connect` / `live-tunnel` (and
+`live-view-new`) as alternate sources of the `sightmap_upload_url`, but those are
+Subtext Verify tools, not part of this plugin. The upload path here is
+`review-open` → `sightmap_upload_url` → collector (before `review-zoom` /
+`review-snapshot`), which is confirmed working; the instructions now describe only
+that flow.

--- a/skills/subtext-sightmap/SKILL.md
+++ b/skills/subtext-sightmap/SKILL.md
@@ -34,12 +34,9 @@ real corpus.
 
 ### Preferred — side-band upload (whole corpus)
 
-`review-open` returns a single-use `sightmap_upload_url` in its response (so do
-the live tools: `live-connect` returns `sightmap_upload_url`, `live-tunnel`
-returns `sightmapUploadUrl`). Upload the checked-in corpus to that URL with the
-bundled collector script **before** you read anything back — before
-`review-zoom` / `review-snapshot` for a review, or before `live-view-new` for the
-tunnel-first live flow:
+`review-open` returns a single-use `sightmap_upload_url` in its response. Upload
+the checked-in corpus to that URL with the bundled collector script **before**
+you read anything back — before `review-zoom` / `review-snapshot`:
 
 ```bash
 # run from the project root (where .sightmap/ lives):


### PR DESCRIPTION
## Why

The `subtext-sightmap` bridge skill documented `live-connect` / `live-tunnel` (and `live-view-new`) as alternate sources of the `sightmap_upload_url`. Those are **Subtext Verify** tools, not part of this plugin — so a Review-plugin skill was pointing at tools it can't call, which is confusing for anyone with only Subtext installed.

## What

- Rewrote the "Preferred — side-band upload" section to describe only the review flow: `review-open` → `sightmap_upload_url` → collector, before `review-zoom` / `review-snapshot`.
- No behavior change to the collector script or the inline fallback.

## Verification

Confirmed against the live MCP server that `review-open` returns a working `sightmap_upload_url` in its response, so the documented upload path is correct and current.

## Notes

First step of a broader skills-coherence pass. A follow-up will trim the Subtext Verify skill set (which currently duplicates install/usage/foundation guidance and collides on four skill names) down to verify-only content, at which point the "separate Subtext Verify *plugin*" wording elsewhere in these skills will be updated to reflect that Verify is installed manually rather than as a plugin.

Patch changeset included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Skill markdown and changeset only; no runtime or collector behavior changes.
> 
> **Overview**
> **Documentation-only** update to the `subtext-sightmap` bridge skill so upload guidance matches what the Review plugin can actually use.
> 
> The **Preferred — side-band upload** section no longer lists `live-connect`, `live-tunnel`, or `live-view-new` as alternate sources of `sightmap_upload_url` (those belong to Subtext Verify, not this plugin). It now documents a single flow: **`review-open`** → **`sightmap_upload_url`** → **`collect_and_upload_sightmap.py`**, run **before** **`review-zoom`** / **`review-snapshot`**.
> 
> A **patch changeset** records the skill doc fix. The collector script and inline fallback on `review-open` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1d025fcd7f4d726f832bb2669309ada37e81c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->