### PR TITLE
Add Cursor marketplace manifest so Cursor indexers surface the Subtext plugin

### DIFF
--- a/.changeset/cursor-marketplace-manifest.md
+++ b/.changeset/cursor-marketplace-manifest.md
@@ -1,0 +1,5 @@
+---
+"subtext": patch
+---
+
+Add a Cursor-flavored marketplace manifest (`.cursor-plugin/marketplace.json`) listing only the root Subtext plugin. Cursor-style marketplace indexers read `.cursor-plugin/marketplace.json` before `.claude-plugin/marketplace.json`; without it they fall through to the Claude listing, where the external `subtext-verify` GitHub source reference either fails parsing or causes Subtext Verify to be surfaced instead of Subtext. Also teach `sync-manifest-versions.mjs` to keep the new manifest's version in sync.

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "subtext-marketplace",
+  "owner": {
+    "name": "Subtext",
+    "email": "subtext@fullstory.com"
+  },
+  "plugins": [
+    {
+      "name": "subtext",
+      "source": "./",
+      "version": "0.10.2",
+      "description": "Review Subtext session recordings and manage privacy rules",
+      "category": "development",
+      "keywords": [
+        "subtext",
+        "fullstory",
+        "session-replay",
+        "review",
+        "privacy"
+      ],
+      "homepage": "https://subtext.fullstory.com",
+      "author": {
+        "name": "Subtext",
+        "email": "subtext@fullstory.com"
+      }
+    }
+  ]
+}

--- a/scripts/sync-manifest-versions.mjs
+++ b/scripts/sync-manifest-versions.mjs
@@ -41,14 +41,20 @@ for (const rel of PER_HARNESS_MANIFESTS) {
   touched++;
 }
 
-// marketplace.json: version lives under plugins[0].
-const marketplacePath = join(REPO_ROOT, '.claude-plugin/marketplace.json');
-if (existsSync(marketplacePath)) {
+// marketplace listings: version lives under plugins[0].
+const MARKETPLACE_MANIFESTS = [
+  '.claude-plugin/marketplace.json',
+  '.cursor-plugin/marketplace.json',
+];
+
+for (const rel of MARKETPLACE_MANIFESTS) {
+  const marketplacePath = join(REPO_ROOT, rel);
+  if (!existsSync(marketplacePath)) continue;
   const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
   if (marketplace.plugins[0].version !== version) {
     marketplace.plugins[0].version = version;
     writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + '\n');
-    console.log(`sync: .claude-plugin/marketplace.json (plugins[0]) → ${version}`);
+    console.log(`sync: ${rel} (plugins[0]) → ${version}`);
     touched++;
   }
 }


### PR DESCRIPTION
## Summary

- Our indexer resolves `.cursor-plugin/marketplace.json` before `.claude-plugin/marketplace.json`. This repo only ships the Claude listing, whose `subtext-verify` entry uses a Claude-only external GitHub source (`{"source": "github", "repo": "fullstorydev/subtext-verify"}`). So our parsers either fail on that entry or end up surfacing Subtext Verify instead of Subtext.
- This adds a .cursor-plugin/marketplace.json listing only to the root Subtext plugin, so Cursor surfaces the right plugin
- `scripts/sync-manifest-versions.mjs` now syncs the version in both marketplace listings, and a patch changeset is included.