### PR TITLE
fix(release): sync package-lock.json version in version-packages

### DIFF
--- a/scripts/sync-manifest-versions.mjs
+++ b/scripts/sync-manifest-versions.mjs
@@ -3,11 +3,12 @@
 //
 // Changesets only bumps `package.json`; the per-harness plugin.json files
 // (.claude-plugin/, .codex-plugin/, .cursor-plugin/), the Gemini extension
-// manifest (gemini-extension.json), and the marketplace listing carry their
-// own `version` fields that the harnesses' UIs display.
+// manifest (gemini-extension.json), the marketplace listing, and
+// package-lock.json all carry their own `version` fields that changesets
+// leaves untouched.
 // This script reads the post-`changeset version` package.json and writes
-// that version into every manifest, so a future Version PR opens with all
-// manifests already synced.
+// that version into every manifest (and the lockfile), so a future Version PR
+// opens with all version metadata already synced.
 //
 // Wired into `npm run version-packages`, which `release.yml` invokes via
 // `changesets/action`'s `version:` input.
@@ -59,6 +60,30 @@ for (const rel of MARKETPLACE_MANIFESTS) {
   }
 }
 
+// package-lock.json records the package's own version in two places (the
+// top-level `version` and the root package entry `packages[""]`). Changesets
+// bumps package.json but not the lockfile, so sync both here — otherwise a
+// later `npm install` rewrites the committed lockfile and the release's version
+// metadata no longer matches (flagged on the v0.10.3 Version PR).
+const lockPath = join(REPO_ROOT, 'package-lock.json');
+if (existsSync(lockPath)) {
+  const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+  let lockChanged = false;
+  if (lock.version !== version) {
+    lock.version = version;
+    lockChanged = true;
+  }
+  if (lock.packages?.['']?.version !== undefined && lock.packages[''].version !== version) {
+    lock.packages[''].version = version;
+    lockChanged = true;
+  }
+  if (lockChanged) {
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
+    console.log(`sync: package-lock.json → ${version}`);
+    touched++;
+  }
+}
+
 if (touched === 0) {
-  console.log(`sync: all manifests already at ${version}`);
+  console.log(`sync: all version metadata already at ${version}`);
 }


### PR DESCRIPTION
## What

Cursor Bugbot flagged (on the v0.10.3 Version Packages PR, #24) that `package.json` was bumped but `package-lock.json` still recorded the old version at both the top-level `version` and the root package entry `packages[""].version`. A later `npm install` would rewrite the committed lockfile, so the release's version metadata no longer matches.

Root cause: `changeset version` bumps only `package.json`. The `version-packages` script already runs `scripts/sync-manifest-versions.mjs` to propagate the new version into the per-harness manifests (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `gemini-extension.json`, marketplace listings) — but the lockfile was left out. That's the missing step.

## Fix

Extend `sync-manifest-versions.mjs` to also write the new version into `package-lock.json`'s two version fields. It's:
- **hermetic** — a direct field rewrite, no `npm install` / no network / no dependency-tree churn;
- **idempotent** — no-op when already in sync;
- **consistent** — same approach the script already uses for the manifests.

No changeset: this is release-tooling infra (subtext publishes nothing to npm; releases are git tags), and it doesn't change what any harness installs.

## Verification

- Idempotent on the current in-sync tree (`all version metadata already at 0.10.2`, no file changes).
- Reserializing the lockfile is byte-stable, so a bump is a minimal 2-line diff (not a reformat).
- End-to-end: temporarily bumped `package.json` to `0.10.3`, ran the script → `package-lock.json` updated exactly its two version lines (`0.10.2` → `0.10.3`) alongside the manifests; reverted.

## Effect on #24

Once this lands on `main`, the release workflow re-runs `npm run version-packages` and refreshes the existing Version Packages PR (#24), which will then include the synced `package-lock.json`. No manual edit of #24 needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-tooling only: idempotent lockfile field updates with no runtime or install behavior changes beyond keeping version strings aligned at release time.
> 
> **Overview**
> **Extends** `scripts/sync-manifest-versions.mjs` so release version bumps also update **`package-lock.json`**, not only harness manifests and marketplace files.
> 
> After `changeset version` bumps `package.json`, the script now rewrites the lockfile’s top-level **`version`** and **`packages[""].version`** to match—using the same direct JSON rewrite approach (no `npm install`). That closes the gap where a later install would rewrite the committed lockfile and leave version metadata out of sync (as flagged on the v0.10.3 Version PR).
> 
> Comments and the idempotent success log now refer to **“version metadata”** instead of only manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea968ce9c1a54c83b993813d5182d5699c5e83f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->